### PR TITLE
Change name of component, add in `bootstrap()`

### DIFF
--- a/components/index.md
+++ b/components/index.md
@@ -18,12 +18,12 @@ Let's start with a very simple component that lists out our name:
 import {Component, View} from 'angular2/angular2'
 
 @Component({
-  selector: 'my-component'
+  selector: 'my-name'
 })
 @View({
-  inline: "<div>Hello my name is {{name}}. <button (click)="sayMyName()">Say my name</button></div>"
+  template: "<div>Hello my name is {{name}}. <button (click)="sayMyName()">Say my name</button></div>"
 })
-export class MyComponent {
+export class MyNameComponent {
   constructor() {
     this.name = 'Max'
   }
@@ -33,5 +33,28 @@ export class MyComponent {
 }
 ```
 
-When we use the `<my-component></my-component>` tag in our HTML, this component will be created,
+When we use the `<my-name></my-name>` tag in our HTML, this component will be created,
 our constructor called, and rendered.
+
+The way that an Angular application is started is by passing a root component to
+the `bootstrap()` method. Let's add that to our code so that we can test it out.
+
+```javascript
+import {Component, View, bootstrap} from 'angular2/angular2'
+
+@Component({
+  selector: 'my-name'
+})
+@View({
+  template: "<div>Hello my name is {{name}}. <button (click)="sayMyName()">Say my name</button></div>"
+})
+export class MyNameComponent {
+  constructor() {
+    this.name = 'Max'
+  }
+  sayMyName() {
+    console.log('My name is', this.name)
+  }
+}
+bootstrap(MyNameComponent);
+```


### PR DESCRIPTION
Seems like the name of the component is XyzComponent and that maps to an
html element <xyz></xyz> rather than <xyz-component></xyz-component>.
So I added `Name` to `MyComponent` to make it `MyNameComponent` and
changed the tag to be <my-name></my-name>.

In the latest examples I've seen the @View annotations are using
`template` rather than `inline`. I could be wrong there.

Added in a snippet with the `bootstrap()` call as that'll help people
get the example a bit closer to something that works.