### PR TITLE
Use a separate method name

### DIFF
--- a/outputs/index.md
+++ b/outputs/index.md
@@ -49,7 +49,7 @@ Now when we used this component elsewhere in our app, we can bind the event that
 
 ```html
 {% raw %}
-  <user-profile (userUpdated)="userUpdated($event)"></user-profile>
+  <user-profile (userUpdated)="handleUserUpdated($event)"></user-profile>
 {% endraw %}
 ```
 
@@ -58,7 +58,7 @@ Now when we used this component elsewhere in our app, we can bind the event that
 export class SettingsPage {
   constructor(){}
 
-  userUpdated(user) {
+  handleUserUpdated(user) {
     // Handle the event
   }
 }


### PR DESCRIPTION
Using a separate method name than the @Output name so it's a little clearer when reading the code. If I don't read the Events chapter before this, it's a bit confusing to understand which is which.